### PR TITLE
Merge directory and history into environment module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 environment
 ===========
 
-Sets generic Zsh built-in environment options.
+Sets sane Zsh built-in environment options.
 
 Also enables smart URL-pasting. This prevents the user from having to manually escape URLs.
 
 Settings
 --------
+
+By default, the history is set to be saved in `${ZDOTDIR:-${HOME}}/.zhistory`.
+The file path can be customized with:
+
+    HISTFILE=/path/to/.zsh_history
 
 You can set a custom terminal title containing [prompt expansion escape sequences],
 that is redrawn upon directory change. The example below sets the title to show
@@ -17,12 +22,45 @@ the current directory name:
 Zsh options
 -----------
 
-  * `AUTO_RESUME` resumes an existing job before creating a new one.
+### Changing directories
+
+  * `AUTO_CD` performs cd to a directory if the typed command is invalid, but is a directory.
+  * `AUTO_PUSHD` makes cd push the old directory to the directory stack.
+  * `PUSHD_IGNORE_DUPS` does not push multiple copies of the same directory to the stack.
+  * `PUSHD_SILENT` does not print the directory stack after pushd or popd.
+  * `PUSHD_TO_HOME` has pushd without arguments act like `pushd ${HOME}`.
+
+### Expansion and globbing
+
+  * `EXTENDED_GLOB` treats `#`, `~`, and `^` as patterns for filename globbing.
+
+### History
+
+  * `BANG_HIST` performs csh-style '!' expansion.
+  * `HIST_IGNORE_ALL_DUPS` removes older command from the history if a duplicate is to be added.
+  * `HIST_IGNORE_DUPS` does not enter immediate duplicates into the history.
+  * `HIST_IGNORE_SPACE` removes commands from the history that begin with a space.
+  * `HIST_SAVE_NO_DUPS` ommits older commands that duplicate newer ones when saving.
+  * `HIST_VERIFY` doesn't execute the command directly upon history expansion.
+  * `SHARE_HISTORY` causes all terminals to share the same history 'session'.
+
+
+### Input/output
+
   * `INTERACTIVE_COMMENTS` allows comments starting with `#` in the shell.
+  * `NO_CLOBBER` disallows `>` to overwrite existing files. Use `>|` or `>!` instead.
+
+### Job control
+
+  * `AUTO_RESUME` resumes an existing job before creating a new one.
   * `LONG_LIST_JOBS` lists jobs in verbose format by default.
   * `NOTIFY` reports job status immediately instead of waiting for the prompt.
   * `NO_BG_NICE` prevents background jobs being given a lower priority.
   * `NO_CHECK_JOBS` prevents status report of jobs on shell exit.
   * `NO_HUP` prevents SIGHUP to jobs on shell exit.
+
+### Scripts and functions
+
+  * `MULTIOS` performs implicit tees or cats when using multiple redirections.
 
 [prompt expansion escape sequences]: http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Simple-Prompt-Escapes

--- a/README.md
+++ b/README.md
@@ -36,14 +36,12 @@ Zsh options
 
 ### History
 
-  * `BANG_HIST` performs csh-style '!' expansion.
   * `HIST_IGNORE_ALL_DUPS` removes older command from the history if a duplicate is to be added.
   * `HIST_IGNORE_DUPS` does not enter immediate duplicates into the history.
   * `HIST_IGNORE_SPACE` removes commands from the history that begin with a space.
   * `HIST_SAVE_NO_DUPS` ommits older commands that duplicate newer ones when saving.
   * `HIST_VERIFY` doesn't execute the command directly upon history expansion.
   * `SHARE_HISTORY` causes all terminals to share the same history 'session'.
-
 
 ### Input/output
 
@@ -54,13 +52,8 @@ Zsh options
 
   * `AUTO_RESUME` resumes an existing job before creating a new one.
   * `LONG_LIST_JOBS` lists jobs in verbose format by default.
-  * `NOTIFY` reports job status immediately instead of waiting for the prompt.
   * `NO_BG_NICE` prevents background jobs being given a lower priority.
   * `NO_CHECK_JOBS` prevents status report of jobs on shell exit.
   * `NO_HUP` prevents SIGHUP to jobs on shell exit.
-
-### Scripts and functions
-
-  * `MULTIOS` performs implicit tees or cats when using multiple redirections.
 
 [prompt expansion escape sequences]: http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Simple-Prompt-Escapes

--- a/init.zsh
+++ b/init.zsh
@@ -49,9 +49,6 @@ setopt EXTENDED_GLOB
 # History
 #
 
-# Perform textual history expansion, csh-style, treating the character ‘!’ specially.
-setopt BANG_HIST
-
 # If a new command line being added to the history list duplicates an older one,
 # the older command is removed from the list (even if it is not the previous event).
 setopt HIST_IGNORE_ALL_DUPS
@@ -98,10 +95,6 @@ setopt AUTO_RESUME
 # List jobs in the long format by default.
 setopt LONG_LIST_JOBS
 
-# Report the status of background jobs immediately, rather than waiting until
-# just before printing a prompt.
-setopt NOTIFY
-
 # Prevent runing all background jobs at a lower priority.
 setopt NO_BG_NICE
 
@@ -112,13 +105,6 @@ setopt NO_CHECK_JOBS
 
 # Prevent sending the HUP signal to running jobs when the shell exits.
 setopt NO_HUP
-
-#
-# Scripts and functions
-#
-
-# Perform implicit tees or cats when multiple redirections are attempted.
-setopt MULTIOS
 
 
 # Set less or more as the default pager.

--- a/init.zsh
+++ b/init.zsh
@@ -1,35 +1,125 @@
 #
-# generic options and environment settings
+# Generic options and environment settings
 #
 
 # Use smart URL pasting and escaping.
 autoload -Uz bracketed-paste-url-magic && zle -N bracketed-paste bracketed-paste-url-magic
 autoload -Uz url-quote-magic && zle -N self-insert url-quote-magic
 
-# Treat single word simple commands without redirection as candidates for resumption of an existing job.
-setopt AUTO_RESUME
+# The file to save the history in.
+: ${HISTFILE="${ZDOTDIR:-${HOME}}/.zhistory"}
+
+# The maximum number of events stored in the internal history list and in the history file.
+HISTSIZE=10000
+SAVEHIST=10000
+
+# Remove path separtor from WORDCHARS.
+WORDCHARS=${WORDCHARS//[\/]}
+
+
+#
+# Changing directories
+#
+
+# If a command is issued that can’t be executed as a normal command, and the
+# command is the name of a directory, perform the cd command to that directory.
+setopt AUTO_CD
+
+# Make cd push the old directory onto the directory stack.
+setopt AUTO_PUSHD
+
+# Don’t push multiple copies of the same directory onto the directory stack.
+setopt PUSHD_IGNORE_DUPS
+
+# Do not print the directory stack after pushd or popd.
+setopt PUSHD_SILENT
+
+# Have pushd with no arguments act like ‘pushd ${HOME}’.
+setopt PUSHD_TO_HOME
+
+#
+# Expansion and globbing
+#
+
+# Treat the ‘#’, ‘~’ and ‘^’ characters as part of patterns for filename generation,
+# etc. (An initial unquoted ‘~’ always produces named directory expansion.)
+setopt EXTENDED_GLOB
+
+#
+# History
+#
+
+# Perform textual history expansion, csh-style, treating the character ‘!’ specially.
+setopt BANG_HIST
+
+# If a new command line being added to the history list duplicates an older one,
+# the older command is removed from the list (even if it is not the previous event).
+setopt HIST_IGNORE_ALL_DUPS
+
+# Do not enter command lines into the history list if they are duplicates of the
+# previous event.
+setopt HIST_IGNORE_DUPS
+
+# Remove command lines from the history list when the first character on the
+# line is a space, or when one of the expanded aliases contains a leading space.
+setopt HIST_IGNORE_SPACE
+
+# When writing out the history file, older commands that duplicate newer ones are omitted.
+setopt HIST_SAVE_NO_DUPS
+
+# Whenever the user enters a line with history expansion, don't execute the line directly;
+# instead, perform history expansion and reload the line into the editing buffer.
+setopt HIST_VERIFY
+
+# This option both imports new commands from the history file, and also causes your
+# typed commands to be appended to the history file (like specifying INC_APPEND_HISTORY).
+# The history lines are also output with timestamps ala EXTENDED_HISTORY.
+setopt SHARE_HISTORY
+
+#
+# Input/output
+#
 
 # Allow comments starting with `#` even in interactive shells.
 setopt INTERACTIVE_COMMENTS
 
+# Disallow ‘>’ redirection to overwrite existing files.
+# ‘>|’ or ‘>!’ must be used to overwrite a file.
+setopt NO_CLOBBER
+
+#
+# Job control
+#
+
+# Treat single word simple commands without redirection as candidates for
+# resumption of an existing job.
+setopt AUTO_RESUME
+
 # List jobs in the long format by default.
 setopt LONG_LIST_JOBS
 
-# Report the status of background jobs immediately, rather than waiting until just before printing a prompt.
+# Report the status of background jobs immediately, rather than waiting until
+# just before printing a prompt.
 setopt NOTIFY
 
 # Prevent runing all background jobs at a lower priority.
 setopt NO_BG_NICE
 
-# Prevent reporting the status of background and suspended jobs before exiting a shell with job control.
-# NO_CHECK_JOBS is best used only in combination with NO_HUP, else such jobs will be killed automatically.
+# Prevent reporting the status of background and suspended jobs before exiting a
+# shell with job control. NO_CHECK_JOBS is best used only in combination with
+# NO_HUP, else such jobs will be killed automatically.
 setopt NO_CHECK_JOBS
 
 # Prevent sending the HUP signal to running jobs when the shell exits.
 setopt NO_HUP
 
-# Remove path separtor from WORDCHARS.
-WORDCHARS=${WORDCHARS//[\/]}
+#
+# Scripts and functions
+#
+
+# Perform implicit tees or cats when multiple redirections are attempted.
+setopt MULTIOS
+
 
 # Set less or more as the default pager.
 if (( ! ${+PAGER} )); then


### PR DESCRIPTION
So we can remove the directory and history modules. Other stuff they eventually do will be moved to the utility module.

Why not? I don't think anyone would want to enable the "sane" options just in one of these areas separately...