### PR TITLE
Update term title before/after command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@ Also enables smart URL-pasting. This prevents the user from having to manually e
 Settings
 --------
 
-You can set a custom terminal title containing [prompt expansion escape sequences],
-that is redrawn upon directory change. The example below sets the title to show
-the current directory name:
+You can set a custom terminal title containing [prompt expansion escape sequences], that is redrawn before and after any command is executed. The example below sets the title to show the current directory name and command running in the terminal:
 
-    zstyle ':zim:environment' termtitle '%1~'
+    zstyle ':zim:environment' termtitle '%1~ $1'
 
 Zsh options
 -----------

--- a/init.zsh
+++ b/init.zsh
@@ -40,17 +40,18 @@ if (( ! ${+PAGER} )); then
   fi
 fi
 
-# sets the window title and updates upon directory change
+# sets the window title and updates before and after execution of commands
 # more work probably needs to be done here to support multiplexers
 case ${TERM} in
   xterm*|*rxvt)
-    termtitle_chpwd() {
+    termtitle_update() {
       local ztermtitle
       if zstyle -s ':zim:environment' termtitle 'ztermtitle'; then
         print -Pn "\e]0;${ztermtitle}\a"
       fi
     }
-    autoload -Uz add-zsh-hook && add-zsh-hook chpwd termtitle_chpwd
-    termtitle_chpwd  # we execute it once to initialize the window title
+    autoload -Uz add-zsh-hook \
+      && add-zsh-hook precmd termtitle_update \
+      && add-zsh-hook preexec termtitle_update
     ;;
 esac


### PR DESCRIPTION
Allows using the current command (eg. vim) in the term title. Note that
the precmd hook is needed to reset the terminal title after the current
command exits, making the chpwd hook redundant.