### PR TITLE
Set values of HISTSIZE and SAVEHIST unconditionally

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -37,8 +37,8 @@ setopt EXTENDED_GLOB
 
 # The maximum number of events stored internally and saved in the history file.
 # The former is greater than the latter in case user wants HIST_EXPIRE_DUPS_FIRST.
-: ${HISTSIZE=11000}
-: ${SAVEHIST=10000}
+HISTSIZE=11000
+SAVEHIST=10000
 
 # Don't display duplicates when searching the history.
 setopt HIST_FIND_NO_DUPS


### PR DESCRIPTION
Fixes #3

`HISTSIZE` and `SAVEHIST` being special variables, their value is always set by Zsh. Therefore, the parameter expansion caused Zim's values to never be assigned.

Partially reverts commit 4293dd8059b1635398fb0da310da3d3399cd49b7